### PR TITLE
atlasmapper-117 Avoid parsing documents that are known to be unparsable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>au.gov.aims</groupId>
     <artifactId>atlasmapper</artifactId>
     <packaging>war</packaging>
-    <version>2.0.3</version>
+    <version>2.0.4</version>
     <name>AtlasMapper server and clients</name>
     <description>This application compiled as a single War, that can be deployed in Tomcat, without any other dependency.\n\
 It contains:\n\


### PR DESCRIPTION
Issue #117 v2.0.4
- Skip parsing when the document is not re-downloaded and last parsing (of the document) failed.