### PR TITLE
atlasmapper-98 Renaming a data source ID results in broken layers in …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>au.gov.aims</groupId>
     <artifactId>atlasmapper</artifactId>
     <packaging>war</packaging>
-    <version>2.0.7</version>
+    <version>2.0.8</version>
     <name>AtlasMapper server and clients</name>
     <description>This application compiled as a single War, that can be deployed in Tomcat, without any other dependency.\n\
 It contains:\n\

--- a/src/main/java/au/gov/aims/atlasmapperserver/ClientConfig.java
+++ b/src/main/java/au/gov/aims/atlasmapperserver/ClientConfig.java
@@ -267,6 +267,66 @@ public class ClientConfig extends AbstractRunnableConfig<ClientConfigThread> {
         super(configManager, new ClientConfigThread());
     }
 
+    public void removeDataSource(String dataSourceId) {
+        if (Utils.isNotBlank(dataSourceId)) {
+            JSONArray currentDataSources = this.getDataSources();
+            JSONArray newDataSources = new JSONArray();
+
+            if (currentDataSources != null) {
+                for (int i=0; i < currentDataSources.length(); i++) {
+                    String clientDataSourceId = currentDataSources.optString(i, null);
+                    if (Utils.isNotBlank(clientDataSourceId) && !dataSourceId.equals(clientDataSourceId)) {
+                        newDataSources.put(clientDataSourceId);
+                    }
+                }
+            }
+
+            this.setDataSources(newDataSources);
+        }
+    }
+
+    public void addDataSource(String dataSourceId) {
+        if (Utils.isNotBlank(dataSourceId)) {
+            boolean alreadyThere = false;
+            for (int i=0; i < this.dataSources.length() && !alreadyThere; i++) {
+                String clientDataSourceId = this.dataSources.optString(i, null);
+                if (dataSourceId.equals(clientDataSourceId)) {
+                    alreadyThere = true;
+                }
+            }
+
+            if (!alreadyThere) {
+                this.dataSources.put(dataSourceId);
+            }
+        }
+    }
+
+    /**
+     * Replace oldDataSourceId with newDataSourceId in the list of data source used by the client.
+     * This is used when a data source ID is modified.
+     * @param oldDataSourceId The old ID of the data source before the update.
+     * @param newDataSourceId The new ID of the data source after the update.
+     */
+    public void replaceDataSource(String oldDataSourceId, String newDataSourceId) {
+        if (Utils.isNotBlank(oldDataSourceId) && Utils.isNotBlank(newDataSourceId)) {
+            JSONArray currentDataSources = this.getDataSources();
+            JSONArray newDataSources = new JSONArray();
+
+            if (currentDataSources != null) {
+                for (int i=0; i < currentDataSources.length(); i++) {
+                    String clientDataSourceId = currentDataSources.optString(i, null);
+                    if (oldDataSourceId.equals(clientDataSourceId)) {
+                        newDataSources.put(newDataSourceId);
+                    } else {
+                        newDataSources.put(clientDataSourceId);
+                    }
+                }
+            }
+
+            this.setDataSources(newDataSources);
+        }
+    }
+
     public Map<String, DataSourceWrapper> loadDataSources() throws FileNotFoundException, JSONException {
         Map<String, DataSourceWrapper> dataSources = new HashMap<String, DataSourceWrapper>();
         JSONArray dataSourcesArray = this.getDataSources();
@@ -278,7 +338,9 @@ public class ClientConfig extends AbstractRunnableConfig<ClientConfigThread> {
                             this.getConfigManager().getApplicationFolder(),
                             clientDataSourceId);
 
-                    dataSources.put(clientDataSourceId, dataSourceWrapper);
+                    if (dataSourceWrapper != null) {
+                        dataSources.put(clientDataSourceId, dataSourceWrapper);
+                    }
                 }
             }
         }

--- a/src/main/java/au/gov/aims/atlasmapperserver/ConfigManager.java
+++ b/src/main/java/au/gov/aims/atlasmapperserver/ConfigManager.java
@@ -637,18 +637,44 @@ public class ConfigManager {
                     Integer dataSourceId = dataJSonObj.optInt("id", -1);
                     AbstractDataSourceConfig dataSourceConfig = configs.get1(dataSourceId);
                     if (dataSourceConfig != null) {
+                        String oldDataSourceStrId = dataSourceConfig.getDataSourceId();
+                        File oldDataSourceStateFile = dataSourceConfig.getCacheStateFile();
+
                         // Update the object using the value from the form
                         dataSourceConfig.update(dataJSonObj, true);
                         dataSourceConfig.setModified(true);
                         this.ensureUniqueness(dataSourceConfig);
+
+                        String newDataSourceStrId = dataSourceConfig.getDataSourceId();
+                        File newDataSourceStateFile = dataSourceConfig.getCacheStateFile();
+
+                        // Rename data source state file
+                        if (newDataSourceStateFile != null && newDataSourceStateFile.exists()) {
+                            newDataSourceStateFile.delete();
+                        }
+                        if (oldDataSourceStateFile != null && oldDataSourceStateFile.exists()) {
+                            if (newDataSourceStateFile != null) {
+                                oldDataSourceStateFile.renameTo(newDataSourceStateFile);
+                            } else {
+                                oldDataSourceStateFile.delete();
+                            }
+                        }
+
+                        // Update references in clients
+                        if (oldDataSourceStrId != null && !oldDataSourceStrId.equals(newDataSourceStrId)) {
+                            if (this.clientConfigs != null && !this.clientConfigs.isEmpty()) {
+                                for (ClientConfig clientConfig : this.clientConfigs.values()) {
+                                    clientConfig.replaceDataSource(oldDataSourceStrId, newDataSourceStrId);
+                                }
+                                ConfigHelper.save();
+                            }
+                        }
                     }
                 }
             }
         }
     }
-    public synchronized void destroyDataSourceConfig(ServletRequest request) throws JSONException, IOException, RevivableThreadInterruptedException {
-        RevivableThread.checkForInterruption();
-
+    public synchronized void destroyDataSourceConfig(ServletRequest request) throws JSONException, IOException {
         if (request == null) {
             return;
         }
@@ -664,6 +690,8 @@ public class ConfigManager {
                 if (dataJSonObj != null) {
                     Integer rowId = dataJSonObj.optInt("id", -1);
                     AbstractDataSourceConfig dataSourceConfig = configs.remove1(rowId);
+                    // Delete data source state file from disk (example: "datasources/google.json")
+                    dataSourceConfig.deleteCachedStateFile();
 
                     // Clear dataSource cache since it doesn't exist anymore
                     String dataSourceId = dataSourceConfig.getDataSourceId();
@@ -674,7 +702,13 @@ public class ConfigManager {
                                 dataSourceId, Utils.getExceptionMessage(ex)), ex);
                     }
 
-                    RevivableThread.checkForInterruption();
+                    // Remove references in clients
+                    if (this.clientConfigs != null && !this.clientConfigs.isEmpty()) {
+                        for (ClientConfig clientConfig : this.clientConfigs.values()) {
+                            clientConfig.removeDataSource(dataSourceId);
+                        }
+                        ConfigHelper.save();
+                    }
                 }
             }
         }

--- a/src/main/java/au/gov/aims/atlasmapperserver/cache/URLCache.java
+++ b/src/main/java/au/gov/aims/atlasmapperserver/cache/URLCache.java
@@ -263,9 +263,7 @@ public class URLCache {
     }
 
     public void deleteEntity(String entityId)
-            throws RevivableThreadInterruptedException, SQLException, IOException, ClassNotFoundException {
-
-        RevivableThread.checkForInterruption();
+            throws SQLException, IOException, ClassNotFoundException {
 
         // cleanUp will remove all association with entityId, then will removed entries that are unused.
         this.cleanUp(entityId, 0);

--- a/src/main/java/au/gov/aims/atlasmapperserver/dataSourceConfig/AbstractDataSourceConfig.java
+++ b/src/main/java/au/gov/aims/atlasmapperserver/dataSourceConfig/AbstractDataSourceConfig.java
@@ -184,7 +184,7 @@ public abstract class AbstractDataSourceConfig extends AbstractRunnableConfig<Ab
     }
 
     public static DataSourceWrapper load(File dataSourceSavedStateFile) throws FileNotFoundException, JSONException {
-        if (!dataSourceSavedStateFile.exists()) {
+        if (dataSourceSavedStateFile == null || !dataSourceSavedStateFile.exists()) {
             return null;
         }
 
@@ -219,10 +219,13 @@ public abstract class AbstractDataSourceConfig extends AbstractRunnableConfig<Ab
         }
     }
 
-    public void deleteCachedState() {
+    public File getCacheStateFile() {
         File applicationFolder = this.getConfigManager().getApplicationFolder();
-        File dataSourceCatalogFile = FileFinder.getDataSourcesCatalogFile(applicationFolder, this.dataSourceId);
+        return FileFinder.getDataSourcesCatalogFile(applicationFolder, this.dataSourceId);
+    }
 
+    public void deleteCachedStateFile() {
+        File dataSourceCatalogFile = this.getCacheStateFile();
         if (dataSourceCatalogFile.exists()) {
             dataSourceCatalogFile.delete();
         }


### PR DESCRIPTION
…client

Issue #98 v2.0.8
- When a data source ID is changed, rename its state file and update clients that uses the data source.
- When a data source is deleted, remove its state file and remove reference to the data source in clients.