### PR TITLE
atlasmapper-126 NPE when generating a client after changing a data so…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>au.gov.aims</groupId>
     <artifactId>atlasmapper</artifactId>
     <packaging>war</packaging>
-    <version>2.0.8</version>
+    <version>2.0.9</version>
     <name>AtlasMapper server and clients</name>
     <description>This application compiled as a single War, that can be deployed in Tomcat, without any other dependency.\n\
 It contains:\n\

--- a/src/main/java/au/gov/aims/atlasmapperserver/ConfigManager.java
+++ b/src/main/java/au/gov/aims/atlasmapperserver/ConfigManager.java
@@ -637,30 +637,17 @@ public class ConfigManager {
                     Integer dataSourceId = dataJSonObj.optInt("id", -1);
                     AbstractDataSourceConfig dataSourceConfig = configs.get1(dataSourceId);
                     if (dataSourceConfig != null) {
+                        // Delete data source state file (it contains reference to the data source ID, it needs to be regenerated)
+                        dataSourceConfig.deleteCachedStateFile();
                         String oldDataSourceStrId = dataSourceConfig.getDataSourceId();
-                        File oldDataSourceStateFile = dataSourceConfig.getCacheStateFile();
 
                         // Update the object using the value from the form
                         dataSourceConfig.update(dataJSonObj, true);
                         dataSourceConfig.setModified(true);
                         this.ensureUniqueness(dataSourceConfig);
 
-                        String newDataSourceStrId = dataSourceConfig.getDataSourceId();
-                        File newDataSourceStateFile = dataSourceConfig.getCacheStateFile();
-
-                        // Rename data source state file
-                        if (newDataSourceStateFile != null && newDataSourceStateFile.exists()) {
-                            newDataSourceStateFile.delete();
-                        }
-                        if (oldDataSourceStateFile != null && oldDataSourceStateFile.exists()) {
-                            if (newDataSourceStateFile != null) {
-                                oldDataSourceStateFile.renameTo(newDataSourceStateFile);
-                            } else {
-                                oldDataSourceStateFile.delete();
-                            }
-                        }
-
                         // Update references in clients
+                        String newDataSourceStrId = dataSourceConfig.getDataSourceId();
                         if (oldDataSourceStrId != null && !oldDataSourceStrId.equals(newDataSourceStrId)) {
                             if (this.clientConfigs != null && !this.clientConfigs.isEmpty()) {
                                 for (ClientConfig clientConfig : this.clientConfigs.values()) {

--- a/src/main/java/au/gov/aims/atlasmapperserver/Utils.java
+++ b/src/main/java/au/gov/aims/atlasmapperserver/Utils.java
@@ -466,7 +466,8 @@ public class Utils {
     }
 
     public static String getExceptionMessage(Throwable ex) {
-        return getExceptionMessage(ex, "No message available");
+        String defaultMsg = ex == null ? "No message available" : ex.getClass().getName();
+        return getExceptionMessage(ex, defaultMsg);
     }
     public static String getExceptionMessage(Throwable ex, String defaultMsg) {
         String msg = null;
@@ -487,7 +488,7 @@ public class Utils {
                 msg = getExceptionMessage(ex.getCause(), defaultMsg);
             }
         }
-        if (msg == null || msg.isEmpty()) {
+        if (Utils.isBlank(msg)) {
             msg = defaultMsg;
         }
         return msg;

--- a/src/main/java/au/gov/aims/atlasmapperserver/servlet/compression/GZIPResponseWrapper.java
+++ b/src/main/java/au/gov/aims/atlasmapperserver/servlet/compression/GZIPResponseWrapper.java
@@ -45,102 +45,104 @@ import java.io.PrintWriter;
  */
 public class GZIPResponseWrapper extends HttpServletResponseWrapper {
 
-	protected HttpServletResponse origResponse = null;
-	protected ServletOutputStream stream = null;
-	protected PrintWriter writer = null;
+    protected HttpServletResponse origResponse = null;
+    protected ServletOutputStream stream = null;
+    protected PrintWriter writer = null;
 
-	/**
-	 * Create a new GZIPResponseWrapper
-	 *
-	 * @param response Original HTTP servlet response
-	 */
-	public GZIPResponseWrapper(HttpServletResponse response) {
-		super(response);
-		this.origResponse = response;
-	}
+    /**
+     * Create a new GZIPResponseWrapper
+     *
+     * @param response Original HTTP servlet response
+     */
+    public GZIPResponseWrapper(HttpServletResponse response) {
+        super(response);
+        this.origResponse = response;
+    }
 
-	/**
-	 * Create a new ServletOutputStream which returns a GZIPResponseStream
-	 *
-	 * @return GZIPResponseStream object
-	 * @throws IOException If there is an error creating the response stream
-	 */
-	public ServletOutputStream createOutputStream() throws IOException {
-		return (new GZIPResponseStream(this.origResponse));
-	}
+    /**
+     * Create a new ServletOutputStream which returns a GZIPResponseStream
+     *
+     * @return GZIPResponseStream object
+     * @throws IOException If there is an error creating the response stream
+     */
+    public ServletOutputStream createOutputStream() throws IOException {
+        return (new GZIPResponseStream(this.origResponse));
+    }
 
-	/**
-	 * Finish the response
-	 */
-	public void finishResponse() throws IOException {
-		try {
-			if (this.writer != null) {
-				this.writer.close();
-			}
-		} finally {
-			if (this.stream != null) {
-				this.stream.close();
-			}
-		}
-	}
+    /**
+     * Finish the response
+     */
+    public void finishResponse() throws IOException {
+        try {
+            if (this.writer != null) {
+                this.writer.close();
+            }
+        } finally {
+            if (this.stream != null) {
+                this.stream.close();
+            }
+        }
+    }
 
-	/**
-	 * Flush the output buffer
-	 *
-	 * @throws IOException If there is an error flushing the buffer
-	 */
-	@Override
-	public void flushBuffer() throws IOException {
-		this.stream.flush();
-	}
+    /**
+     * Flush the output buffer
+     *
+     * @throws IOException If there is an error flushing the buffer
+     */
+    @Override
+    public void flushBuffer() throws IOException {
+        if (this.stream != null) {
+            this.stream.flush();
+        }
+    }
 
-	/**
-	 * Retrieve the output stream for this response wrapper
-	 *
-	 * @return {@link #createOutputStream()}
-	 * @throws IOException If there is an error retrieving the output stream
-	 */
-	@Override
-	public ServletOutputStream getOutputStream() throws IOException {
-		if (this.writer != null) {
-			throw new IllegalStateException("getWriter() has already been called.");
-		}
+    /**
+     * Retrieve the output stream for this response wrapper
+     *
+     * @return {@link #createOutputStream()}
+     * @throws IOException If there is an error retrieving the output stream
+     */
+    @Override
+    public ServletOutputStream getOutputStream() throws IOException {
+        if (this.writer != null) {
+            throw new IllegalStateException("getWriter() has already been called.");
+        }
 
-		if (this.stream == null) {
-			this.stream = this.createOutputStream();
-		}
+        if (this.stream == null) {
+            this.stream = this.createOutputStream();
+        }
 
-		return this.stream;
-	}
+        return this.stream;
+    }
 
-	/**
-	 * Retrieve a writer for this response wrapper
-	 *
-	 * @return PrintWriter that wraps an OutputStreamWriter (using UTF-8 as encoding)
-	 * @throws IOException If there is an error retrieving the writer
-	 */
-	@Override
-	public PrintWriter getWriter() throws IOException {
-		if (this.writer != null) {
-			return (this.writer);
-		}
+    /**
+     * Retrieve a writer for this response wrapper
+     *
+     * @return PrintWriter that wraps an OutputStreamWriter (using UTF-8 as encoding)
+     * @throws IOException If there is an error retrieving the writer
+     */
+    @Override
+    public PrintWriter getWriter() throws IOException {
+        if (this.writer != null) {
+            return (this.writer);
+        }
 
-		if (this.stream != null) {
-			throw new IllegalStateException("getOutputStream() has already been called.");
-		}
+        if (this.stream != null) {
+            throw new IllegalStateException("getOutputStream() has already been called.");
+        }
 
-		this.stream = this.createOutputStream();
-		this.writer = new PrintWriter(new OutputStreamWriter(this.stream, "UTF-8"));
+        this.stream = this.createOutputStream();
+        this.writer = new PrintWriter(new OutputStreamWriter(this.stream, "UTF-8"));
 
-		return this.writer;
-	}
+        return this.writer;
+    }
 
-	/**
-	 * Set the content length for the response. Currently a no-op.
-	 *
-	 * @param length Content length
-	 */
-	@Override
-	public void setContentLength(int length) {
-	}
+    /**
+     * Set the content length for the response. Currently a no-op.
+     *
+     * @param length Content length
+     */
+    @Override
+    public void setContentLength(int length) {
+    }
 }

--- a/src/main/java/au/gov/aims/atlasmapperserver/thread/AbstractDataSourceConfigThread.java
+++ b/src/main/java/au/gov/aims/atlasmapperserver/thread/AbstractDataSourceConfigThread.java
@@ -106,6 +106,8 @@ public class AbstractDataSourceConfigThread extends AbstractConfigThread {
 
         } catch (RevivableThreadInterruptedException ex) {
             logger.log(Level.SEVERE, "Data source generation cancelled by user.", ex);
+        } catch (Exception ex) {
+            logger.log(Level.SEVERE, "Error occurred while rebuilding the data source.", ex);
         }
     }
 

--- a/src/main/java/au/gov/aims/atlasmapperserver/thread/ClientConfigThread.java
+++ b/src/main/java/au/gov/aims/atlasmapperserver/thread/ClientConfigThread.java
@@ -222,6 +222,8 @@ public class ClientConfigThread extends AbstractConfigThread {
 
         } catch (RevivableThreadInterruptedException ex) {
             logger.log(Level.SEVERE, "Client generation cancelled by user.", ex);
+        } catch (Exception ex) {
+            logger.log(Level.SEVERE, "Error occurred while generating the client.", ex);
         }
     }
 
@@ -424,11 +426,14 @@ public class ClientConfigThread extends AbstractConfigThread {
                     // Raw data source object containing values before override
 
                     if (dataSources != null) {
-                        dataSource = new DataSourceWrapper(dataSources.optJSONObject(dataSourceId));
+                        JSONObject jsonDataSource = dataSources.optJSONObject(dataSourceId);
+                        if (jsonDataSource != null) {
+                            dataSource = new DataSourceWrapper(jsonDataSource);
+                        }
                     }
 
                     if (dataSource == null) {
-                        logger.log(Level.WARNING, String.format("The client %s define a layer %s using an invalid data source %s.",
+                        logger.log(Level.WARNING, String.format("The client *%s* define the layer *%s* using the invalid data source *%s*.",
                                 this.clientConfig.getClientName(), layerName, dataSourceId));
                     } else {
                         String dataSourceName = dataSource.getDataSourceName();

--- a/src/main/java/au/gov/aims/atlasmapperserver/thread/ThreadLog.java
+++ b/src/main/java/au/gov/aims/atlasmapperserver/thread/ThreadLog.java
@@ -1,5 +1,6 @@
 package au.gov.aims.atlasmapperserver.thread;
 
+import au.gov.aims.atlasmapperserver.Utils;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -48,6 +49,7 @@ public class ThreadLog {
 
         Throwable ex = this.getException();
         if (ex != null) {
+            json.put("exception", Utils.getExceptionMessage(ex));
             json.put("stacktrace", ex.getStackTrace());
         }
 

--- a/src/main/webapp/javascript/Frameset.js
+++ b/src/main/webapp/javascript/Frameset.js
@@ -425,12 +425,17 @@ Ext.define('Frameset', {
 
         // Add exception stacktrace if available
         var stacktrace = '';
-        if (log.stacktrace && log.stacktrace.length > 0) {
+        if (log.exception || (log.stacktrace && log.stacktrace.length > 0)) {
             stacktrace += '<div class="stacktrace">';
             stacktrace += '<div class="uncollapse" onclick="showStacktrace(this);">[Stacktrace]</div>';
             stacktrace += '<div class="collapsed"><ul>';
-            for (var i=0; i<log.stacktrace.length; i++) {
-                stacktrace += '<li>' + Ext.String.htmlEncode(log.stacktrace[i]) + '</li>';
+            if (log.exception) {
+                stacktrace += '<li>' + Ext.String.htmlEncode(log.exception) + '</li>';
+            }
+            if (log.stacktrace && log.stacktrace.length > 0) {
+                for (var i=0; i<log.stacktrace.length; i++) {
+                    stacktrace += '<li>' + Ext.String.htmlEncode(log.stacktrace[i]) + '</li>';
+                }
             }
             stacktrace += '</ul></div>';
             stacktrace += '</div>';

--- a/src/main/webapp/resources/style.css
+++ b/src/main/webapp/resources/style.css
@@ -92,6 +92,9 @@ ol.bullet-list > li {
     background-color: #000000;
     color: #FFFFFF;
 }
+.logs-panel .x-panel-body em {
+    font-style: italic;
+}
 .logs-panel .x-panel-body a {
     color: #FFFFFF;
 }


### PR DESCRIPTION
…urce ID

Issue #126 v2.0.9
- Catch runtime exception in data source and client generation and output error message to the user.
- When data source ID is changed, delete state file instead of renaming it.
- In Utils.getExceptionMessage, use the exception class name when no error message is available (to get "java.lang.NullPointerException" for NPE instead of "No message available")
- Show the error message with the stack trace in the log window (when available)