### PR TITLE
atlasmapper-128 Can't parse some ArcGIS service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>au.gov.aims</groupId>
     <artifactId>atlasmapper</artifactId>
     <packaging>war</packaging>
-    <version>2.0.9</version>
+    <version>2.0.10</version>
     <name>AtlasMapper server and clients</name>
     <description>This application compiled as a single War, that can be deployed in Tomcat, without any other dependency.\n\
 It contains:\n\

--- a/src/test/java/au/gov/aims/atlasmapperserver/layerGenerator/ArcGISMapServerLayerGeneratorTest.java
+++ b/src/test/java/au/gov/aims/atlasmapperserver/layerGenerator/ArcGISMapServerLayerGeneratorTest.java
@@ -1,0 +1,68 @@
+package au.gov.aims.atlasmapperserver.layerGenerator;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ArcGISMapServerLayerGeneratorTest {
+
+    @Test
+    public void testBaseGetJSONUrl() throws Exception {
+        ArcGISMapServerLayerGenerator layerGenerator = new ArcGISMapServerLayerGenerator();
+
+        String arcGISPath = null;
+        String type = null;
+
+        String jsonUrlStr = layerGenerator.getJSONUrl("http://maps2.six.nsw.gov.au/arcgis/rest/services", arcGISPath, type);
+        Assert.assertEquals("http://maps2.six.nsw.gov.au/arcgis/rest/services?f=json&pretty=true", jsonUrlStr);
+
+        jsonUrlStr = layerGenerator.getJSONUrl("http://maps2.six.nsw.gov.au/arcgis/rest/services/", arcGISPath, type);
+        Assert.assertEquals("http://maps2.six.nsw.gov.au/arcgis/rest/services/?f=json&pretty=true", jsonUrlStr);
+
+        jsonUrlStr = layerGenerator.getJSONUrl("http://maps2.six.nsw.gov.au/arcgis/rest/services/sixmaps", arcGISPath, type);
+        Assert.assertEquals("http://maps2.six.nsw.gov.au/arcgis/rest/services/sixmaps?f=json&pretty=true", jsonUrlStr);
+
+        jsonUrlStr = layerGenerator.getJSONUrl("http://maps2.six.nsw.gov.au/arcgis/rest/services/sixmaps/", arcGISPath, type);
+        Assert.assertEquals("http://maps2.six.nsw.gov.au/arcgis/rest/services/sixmaps/?f=json&pretty=true", jsonUrlStr);
+    }
+
+    @Test
+    public void testPathGetJSONUrl() throws Exception {
+        ArcGISMapServerLayerGenerator layerGenerator = new ArcGISMapServerLayerGenerator();
+
+        String arcGISPath = "sixmaps/Cadastre";
+        String type = "MapServer";
+
+        String jsonUrlStr = layerGenerator.getJSONUrl("http://maps2.six.nsw.gov.au/arcgis/rest/services", arcGISPath, type);
+        Assert.assertEquals("http://maps2.six.nsw.gov.au/arcgis/rest/services/sixmaps/Cadastre/MapServer?f=json&pretty=true", jsonUrlStr);
+
+        jsonUrlStr = layerGenerator.getJSONUrl("http://maps2.six.nsw.gov.au/arcgis/rest/services/", arcGISPath, type);
+        Assert.assertEquals("http://maps2.six.nsw.gov.au/arcgis/rest/services/sixmaps/Cadastre/MapServer?f=json&pretty=true", jsonUrlStr);
+
+        jsonUrlStr = layerGenerator.getJSONUrl("http://maps2.six.nsw.gov.au/arcgis/rest/services/sixmaps", arcGISPath, type);
+        Assert.assertEquals("http://maps2.six.nsw.gov.au/arcgis/rest/services/sixmaps/Cadastre/MapServer?f=json&pretty=true", jsonUrlStr);
+
+        jsonUrlStr = layerGenerator.getJSONUrl("http://maps2.six.nsw.gov.au/arcgis/rest/services/sixmaps/", arcGISPath, type);
+        Assert.assertEquals("http://maps2.six.nsw.gov.au/arcgis/rest/services/sixmaps/Cadastre/MapServer?f=json&pretty=true", jsonUrlStr);
+    }
+
+    @Test
+    public void testLayerGetJSONUrl() throws Exception {
+        ArcGISMapServerLayerGenerator layerGenerator = new ArcGISMapServerLayerGenerator();
+
+        String arcGISPath = "sixmaps/Cadastre";
+        String type = "MapServer";
+        String layerId = "0";
+
+        String jsonUrlStr = layerGenerator.getJSONUrl("http://maps2.six.nsw.gov.au/arcgis/rest/services", arcGISPath, type, layerId);
+        Assert.assertEquals("http://maps2.six.nsw.gov.au/arcgis/rest/services/sixmaps/Cadastre/MapServer/0?f=json&pretty=true", jsonUrlStr);
+
+        jsonUrlStr = layerGenerator.getJSONUrl("http://maps2.six.nsw.gov.au/arcgis/rest/services/", arcGISPath, type, layerId);
+        Assert.assertEquals("http://maps2.six.nsw.gov.au/arcgis/rest/services/sixmaps/Cadastre/MapServer/0?f=json&pretty=true", jsonUrlStr);
+
+        jsonUrlStr = layerGenerator.getJSONUrl("http://maps2.six.nsw.gov.au/arcgis/rest/services/sixmaps", arcGISPath, type, layerId);
+        Assert.assertEquals("http://maps2.six.nsw.gov.au/arcgis/rest/services/sixmaps/Cadastre/MapServer/0?f=json&pretty=true", jsonUrlStr);
+
+        jsonUrlStr = layerGenerator.getJSONUrl("http://maps2.six.nsw.gov.au/arcgis/rest/services/sixmaps/", arcGISPath, type, layerId);
+        Assert.assertEquals("http://maps2.six.nsw.gov.au/arcgis/rest/services/sixmaps/Cadastre/MapServer/0?f=json&pretty=true", jsonUrlStr);
+    }
+}


### PR DESCRIPTION
Issue #128 v2.0.10
- Changed the way ArcGIS Service URLs are constructed
- Added test to verify that ArcGIS URLs are constructed as expected
- Throw error earlier when there is no service URL for ArcGIS services