### PR TITLE
atlasmapper-142 Layer count in data source / client list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>au.gov.aims</groupId>
     <artifactId>atlasmapper</artifactId>
     <packaging>war</packaging>
-    <version>2.0.16</version>
+    <version>2.0.17</version>
     <name>AtlasMapper server and clients</name>
     <description>This application compiled as a single War, that can be deployed in Tomcat, without any other dependency.\n\
 It contains:\n\

--- a/src/main/java/au/gov/aims/atlasmapperserver/ClientConfig.java
+++ b/src/main/java/au/gov/aims/atlasmapperserver/ClientConfig.java
@@ -83,6 +83,9 @@ public class ClientConfig extends AbstractRunnableConfig<ClientConfigThread> {
     private String clientName;
 
     @ConfigField
+    private int layerCount;
+
+    @ConfigField
     private String welcomeMsg;
 
     @ConfigField
@@ -614,6 +617,14 @@ public class ClientConfig extends AbstractRunnableConfig<ClientConfigThread> {
 
     public void setClientName(String clientName) {
         this.clientName = clientName;
+    }
+
+    public int getLayerCount() {
+        return this.layerCount;
+    }
+
+    public void setLayerCount(int layerCount) {
+        this.layerCount = layerCount;
     }
 
     public String getWelcomeMsg() {

--- a/src/main/java/au/gov/aims/atlasmapperserver/ConfigManager.java
+++ b/src/main/java/au/gov/aims/atlasmapperserver/ConfigManager.java
@@ -811,7 +811,7 @@ public class ConfigManager {
             return;
         }
 
-        MultiKeyHashMap<Integer, String, ClientConfig> configs = this.getClientConfigs();
+        MultiKeyHashMap<Integer, String, ClientConfig> clientConfigs = this.getClientConfigs();
         JSONArray dataJSonArr = this.getPostedData(request);
         if (dataJSonArr != null) {
             for (int i=0; i<dataJSonArr.length(); i++) {
@@ -819,20 +819,10 @@ public class ConfigManager {
                 if (jsonDataSource != null) {
                     DataSourceWrapper dataSourceWrapper = new DataSourceWrapper(jsonDataSource);
                     Integer clientId = dataSourceWrapper.getId();
-                    ClientConfig clientConfig = configs.get1(clientId);
+                    ClientConfig clientConfig = clientConfigs.get1(clientId);
                     if (clientConfig != null) {
-                        //File oldClientFolder = FileFinder.getAtlasMapperClientFolder(this.applicationFolder, clientConfig, false);
-                        //File oldConfigFolder = FileFinder.getAtlasMapperClientConfigFolder(this.applicationFolder, clientConfig, false);
-
                         clientConfig.update(dataSourceWrapper.getJSON(), true);
                         this.ensureUniqueness(clientConfig);
-
-                        //File newClientFolder = FileFinder.getAtlasMapperClientFolder(this.applicationFolder, clientConfig, false);
-                        //File newConfigFolder = FileFinder.getAtlasMapperClientConfigFolder(this.applicationFolder, clientConfig, false);
-
-                        // Move the client folder. This feature works, but it's an unexpected behaviour.
-                        // The function may be re-added later, with a confirmation window asking the admin if that's what he want to do.
-                        //this.moveClientFolder(oldClientFolder, newClientFolder, oldConfigFolder, newConfigFolder);
                     }
                 }
             }

--- a/src/main/java/au/gov/aims/atlasmapperserver/dataSourceConfig/AbstractDataSourceConfig.java
+++ b/src/main/java/au/gov/aims/atlasmapperserver/dataSourceConfig/AbstractDataSourceConfig.java
@@ -69,6 +69,9 @@ public abstract class AbstractDataSourceConfig extends AbstractRunnableConfig<Ab
     @ConfigField
     private String dataSourceName;
 
+    @ConfigField
+    private int layerCount;
+
     // Label used in the layer tree. Can be used to put multiple datasources into the same tree.
     // Default: dataSourceName
     @ConfigField
@@ -147,6 +150,7 @@ public abstract class AbstractDataSourceConfig extends AbstractRunnableConfig<Ab
             status = "INVALID";
         }
 
+        dataSourceWrapper.setLayerCount(nbLayers);
         dataSourceWrapper.setStatus(status);
 
         AbstractDataSourceConfig.write(applicationFolder, this.dataSourceId, dataSourceWrapper);
@@ -404,6 +408,14 @@ public abstract class AbstractDataSourceConfig extends AbstractRunnableConfig<Ab
         this.dataSourceName = dataSourceName;
     }
 
+    public int getLayerCount() {
+        return this.layerCount;
+    }
+
+    public void setLayerCount(int layerCount) {
+        this.layerCount = layerCount;
+    }
+
     public String getTreeRoot() {
         return this.treeRoot;
     }
@@ -528,6 +540,8 @@ public abstract class AbstractDataSourceConfig extends AbstractRunnableConfig<Ab
                     if (dataSourceSavedState != null) {
                         status = dataSourceSavedState.getStatus();
                         modified = dataSourceSavedState.isModified();
+
+                        dataSourceWrapper.setLayerCount(dataSourceSavedState.getLayerCount());
 
                         // lastModified() returns 0L if the file do not exists of an exception occurred.
                         long timestamp = dataSourceCatalogFile.lastModified();

--- a/src/main/java/au/gov/aims/atlasmapperserver/jsonWrappers/AbstractWrapper.java
+++ b/src/main/java/au/gov/aims/atlasmapperserver/jsonWrappers/AbstractWrapper.java
@@ -29,48 +29,50 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class AbstractWrapper implements Cloneable {
-	private static final Logger LOGGER = Logger.getLogger(AbstractWrapper.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(AbstractWrapper.class.getName());
 
-	protected JSONObject json;
+    protected JSONObject json;
 
-	public AbstractWrapper() {
-		this.json = new JSONObject();
-	}
+    public AbstractWrapper() {
+        this.json = new JSONObject();
+    }
 
-	public AbstractWrapper(JSONObject json) {
-		this.json = json;
-	}
+    public AbstractWrapper(JSONObject json) {
+        this.json = json;
+    }
 
-	public JSONObject getJSON() {
-		return this.json;
-	}
+    public JSONObject getJSON() {
+        return this.json;
+    }
 
-	protected void setValue(String key, Object value) throws JSONException {
-		if (value == null) {
-			this.json.remove(key);
-		} else {
-			this.json.put(key, value);
-		}
-	}
+    protected void setValue(String key, Object value) throws JSONException {
+        if (value == null) {
+            this.json.remove(key);
+        } else {
+            this.json.put(key, value);
+        }
+    }
 
-	public Object clone() {
-		JSONObject jsonClone = new JSONObject();
+    public Object clone() {
+        JSONObject jsonClone = new JSONObject();
 
-		try {
-			Iterator<String> keys = this.json.keys();
-			if (keys != null) {
-				while (keys.hasNext()) {
-					String key = keys.next();
-					jsonClone.put(key, this.json.opt(key));
-				}
-			}
+        try {
+            if (this.json != null) {
+                Iterator<String> keys = this.json.keys();
+                if (keys != null) {
+                    while (keys.hasNext()) {
+                        String key = keys.next();
+                        jsonClone.put(key, this.json.opt(key));
+                    }
+                }
+            }
 
-			return this.getClass().getConstructor(JSONObject.class).newInstance(jsonClone);
-		} catch (Exception e) {
-			LOGGER.log(Level.SEVERE, "Can not clone Object of class {0}: {1}",
-					new String[] { this.getClass().getName(), Utils.getExceptionMessage(e) });
-			LOGGER.log(Level.FINE, "Stack trace: ", e);
-		}
-		return null;
-	}
+            return this.getClass().getConstructor(JSONObject.class).newInstance(jsonClone);
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Can not clone Object of class {0}: {1}",
+                    new String[] { this.getClass().getName(), Utils.getExceptionMessage(e) });
+            LOGGER.log(Level.FINE, "Stack trace: ", e);
+        }
+        return null;
+    }
 }

--- a/src/main/java/au/gov/aims/atlasmapperserver/jsonWrappers/client/ClientWrapper.java
+++ b/src/main/java/au/gov/aims/atlasmapperserver/jsonWrappers/client/ClientWrapper.java
@@ -30,301 +30,301 @@ import org.json.JSONObject;
  * It has been made to manage the Json keys in one location and simplify maintenance.
  */
 public class ClientWrapper extends AbstractWrapper {
-	public ClientWrapper() { super(); }
-	public ClientWrapper(JSONObject json) { super(json); }
+    public ClientWrapper() { super(); }
+    public ClientWrapper(JSONObject json) { super(json); }
 
-	public Double getVersion() {
-		return this.getVersion(null);
-	}
-	public Double getVersion(Double defaultValue) {
-		if (this.json.isNull("version")) {
-			return defaultValue;
-		}
-		return this.json.optDouble("version");
-	}
-	public void setVersion(Double version) throws JSONException {
-		if (version == null && !this.json.isNull("version")) {
-			this.json.remove("version");
-		} else {
-			this.json.put("version", version);
-		}
-	}
+    public Double getVersion() {
+        return this.getVersion(null);
+    }
+    public Double getVersion(Double defaultValue) {
+        if (this.json.isNull("version")) {
+            return defaultValue;
+        }
+        return this.json.optDouble("version");
+    }
+    public void setVersion(Double version) throws JSONException {
+        if (version == null && !this.json.isNull("version")) {
+            this.json.remove("version");
+        } else {
+            this.json.put("version", version);
+        }
+    }
 
-	public String getClientId() {
-		return this.json.optString("clientId", null);
-	}
-	public void setClientId(String clientId) throws JSONException {
-		this.json.put("clientId", clientId);
-	}
+    public String getClientId() {
+        return this.json.optString("clientId", null);
+    }
+    public void setClientId(String clientId) throws JSONException {
+        this.json.put("clientId", clientId);
+    }
 
-	public String getClientName() {
-		return this.json.optString("clientName", null);
-	}
-	public void setClientName(String clientName) throws JSONException {
-		this.json.put("clientName", clientName);
-	}
+    public String getClientName() {
+        return this.json.optString("clientName", null);
+    }
+    public void setClientName(String clientName) throws JSONException {
+        this.json.put("clientName", clientName);
+    }
 
-	public String getAttributions() {
-		return this.json.optString("attributions", null);
-	}
-	public void setAttributions(String attributions) throws JSONException {
-		this.json.put("attributions", attributions);
-	}
+    public String getAttributions() {
+        return this.json.optString("attributions", null);
+    }
+    public void setAttributions(String attributions) throws JSONException {
+        this.json.put("attributions", attributions);
+    }
 
-	public JSONArray getDefaultLayers() {
-		return this.json.optJSONArray("defaultLayers");
-	}
-	public void setDefaultLayers(JSONArray defaultLayers) throws JSONException {
-		this.json.put("defaultLayers", defaultLayers);
-	}
+    public JSONArray getDefaultLayers() {
+        return this.json.optJSONArray("defaultLayers");
+    }
+    public void setDefaultLayers(JSONArray defaultLayers) throws JSONException {
+        this.json.put("defaultLayers", defaultLayers);
+    }
 
-	public String getProjection() {
-		return this.json.optString("projection", null);
-	}
-	public void setProjection(String projection) throws JSONException {
-		this.json.put("projection", projection);
-	}
+    public String getProjection() {
+        return this.json.optString("projection", null);
+    }
+    public void setProjection(String projection) throws JSONException {
+        this.json.put("projection", projection);
+    }
 
-	public JSONObject getMapOptions() {
-		return this.json.optJSONObject("mapOptions");
-	}
-	public void setMapOptions(JSONObject mapOptions) throws JSONException {
-		this.json.put("mapOptions", mapOptions);
-	}
+    public JSONObject getMapOptions() {
+        return this.json.optJSONObject("mapOptions");
+    }
+    public void setMapOptions(JSONObject mapOptions) throws JSONException {
+        this.json.put("mapOptions", mapOptions);
+    }
 
-	public String getLayerInfoServiceUrl() {
-		return this.json.optString("layerInfoServiceUrl", null);
-	}
-	public void setLayerInfoServiceUrl(String layerInfoServiceUrl) throws JSONException {
-		this.json.put("layerInfoServiceUrl", layerInfoServiceUrl);
-	}
+    public String getLayerInfoServiceUrl() {
+        return this.json.optString("layerInfoServiceUrl", null);
+    }
+    public void setLayerInfoServiceUrl(String layerInfoServiceUrl) throws JSONException {
+        this.json.put("layerInfoServiceUrl", layerInfoServiceUrl);
+    }
 
-	public String getDownloadLoggerServiceUrl() {
-		return this.json.optString("downloadLoggerServiceUrl", null);
-	}
-	public void setDownloadLoggerServiceUrl(String downloadLoggerServiceUrl) throws JSONException {
-		this.json.put("downloadLoggerServiceUrl", downloadLoggerServiceUrl);
-	}
+    public String getDownloadLoggerServiceUrl() {
+        return this.json.optString("downloadLoggerServiceUrl", null);
+    }
+    public void setDownloadLoggerServiceUrl(String downloadLoggerServiceUrl) throws JSONException {
+        this.json.put("downloadLoggerServiceUrl", downloadLoggerServiceUrl);
+    }
 
-	public Boolean isShowAddRemoveLayerButtons() {
-		return this.isShowAddRemoveLayerButtons(null);
-	}
-	public Boolean isShowAddRemoveLayerButtons(Boolean defaultValue) {
-		if (this.json.isNull("showAddRemoveLayerButtons")) {
-			return defaultValue;
-		}
-		return this.json.optBoolean("showAddRemoveLayerButtons");
-	}
-	public void setShowAddRemoveLayerButtons(Boolean showAddRemoveLayerButtons) throws JSONException {
-		if (showAddRemoveLayerButtons == null && !this.json.isNull("showAddRemoveLayerButtons")) {
-			this.json.remove("showAddRemoveLayerButtons");
-		} else {
-			this.json.put("showAddRemoveLayerButtons", showAddRemoveLayerButtons);
-		}
-	}
+    public Boolean isShowAddRemoveLayerButtons() {
+        return this.isShowAddRemoveLayerButtons(null);
+    }
+    public Boolean isShowAddRemoveLayerButtons(Boolean defaultValue) {
+        if (this.json.isNull("showAddRemoveLayerButtons")) {
+            return defaultValue;
+        }
+        return this.json.optBoolean("showAddRemoveLayerButtons");
+    }
+    public void setShowAddRemoveLayerButtons(Boolean showAddRemoveLayerButtons) throws JSONException {
+        if (showAddRemoveLayerButtons == null && !this.json.isNull("showAddRemoveLayerButtons")) {
+            this.json.remove("showAddRemoveLayerButtons");
+        } else {
+            this.json.put("showAddRemoveLayerButtons", showAddRemoveLayerButtons);
+        }
+    }
 
-	public String getManualOverride() {
-		return this.json.optString("manualOverride", null);
-	}
-	public void setManualOverride(String manualOverride) throws JSONException {
-		this.json.put("manualOverride", manualOverride);
-	}
+    public String getManualOverride() {
+        return this.json.optString("manualOverride", null);
+    }
+    public void setManualOverride(String manualOverride) throws JSONException {
+        this.json.put("manualOverride", manualOverride);
+    }
 
-	public Boolean isSearchEnabled() {
-		return this.isSearchEnabled(null);
-	}
-	public Boolean isSearchEnabled(Boolean defaultValue) {
-		if (this.json.isNull("searchEnabled")) {
-			return defaultValue;
-		}
-		return this.json.optBoolean("searchEnabled");
-	}
-	public void setSearchEnabled(Boolean searchEnabled) throws JSONException {
-		if (searchEnabled == null && !this.json.isNull("searchEnabled")) {
-			this.json.remove("searchEnabled");
-		} else {
-			this.json.put("searchEnabled", searchEnabled);
-		}
-	}
+    public Boolean isSearchEnabled() {
+        return this.isSearchEnabled(null);
+    }
+    public Boolean isSearchEnabled(Boolean defaultValue) {
+        if (this.json.isNull("searchEnabled")) {
+            return defaultValue;
+        }
+        return this.json.optBoolean("searchEnabled");
+    }
+    public void setSearchEnabled(Boolean searchEnabled) throws JSONException {
+        if (searchEnabled == null && !this.json.isNull("searchEnabled")) {
+            this.json.remove("searchEnabled");
+        } else {
+            this.json.put("searchEnabled", searchEnabled);
+        }
+    }
 
-	public Boolean isPrintEnabled() {
-		return this.isPrintEnabled(null);
-	}
-	public Boolean isPrintEnabled(Boolean defaultValue) {
-		if (this.json.isNull("printEnabled")) {
-			return defaultValue;
-		}
-		return this.json.optBoolean("printEnabled");
-	}
-	public void setPrintEnabled(Boolean printEnabled) throws JSONException {
-		if (printEnabled == null && !this.json.isNull("printEnabled")) {
-			this.json.remove("printEnabled");
-		} else {
-			this.json.put("printEnabled", printEnabled);
-		}
-	}
+    public Boolean isPrintEnabled() {
+        return this.isPrintEnabled(null);
+    }
+    public Boolean isPrintEnabled(Boolean defaultValue) {
+        if (this.json.isNull("printEnabled")) {
+            return defaultValue;
+        }
+        return this.json.optBoolean("printEnabled");
+    }
+    public void setPrintEnabled(Boolean printEnabled) throws JSONException {
+        if (printEnabled == null && !this.json.isNull("printEnabled")) {
+            this.json.remove("printEnabled");
+        } else {
+            this.json.put("printEnabled", printEnabled);
+        }
+    }
 
-	public Boolean isSaveMapEnabled() {
-		return this.isSaveMapEnabled(null);
-	}
-	public Boolean isSaveMapEnabled(Boolean defaultValue) {
-		if (this.json.isNull("saveMapEnabled")) {
-			return defaultValue;
-		}
-		return this.json.optBoolean("saveMapEnabled");
-	}
-	public void setSaveMapEnabled(Boolean saveMapEnabled) throws JSONException {
-		if (saveMapEnabled == null && !this.json.isNull("saveMapEnabled")) {
-			this.json.remove("saveMapEnabled");
-		} else {
-			this.json.put("saveMapEnabled", saveMapEnabled);
-		}
-	}
+    public Boolean isSaveMapEnabled() {
+        return this.isSaveMapEnabled(null);
+    }
+    public Boolean isSaveMapEnabled(Boolean defaultValue) {
+        if (this.json.isNull("saveMapEnabled")) {
+            return defaultValue;
+        }
+        return this.json.optBoolean("saveMapEnabled");
+    }
+    public void setSaveMapEnabled(Boolean saveMapEnabled) throws JSONException {
+        if (saveMapEnabled == null && !this.json.isNull("saveMapEnabled")) {
+            this.json.remove("saveMapEnabled");
+        } else {
+            this.json.put("saveMapEnabled", saveMapEnabled);
+        }
+    }
 
-	public Boolean isMapConfigEnabled() {
-		return this.isMapConfigEnabled(null);
-	}
-	public Boolean isMapConfigEnabled(Boolean defaultValue) {
-		if (this.json.isNull("mapConfigEnabled")) {
-			return defaultValue;
-		}
-		return this.json.optBoolean("mapConfigEnabled");
-	}
-	public void setMapConfigEnabled(Boolean mapConfigEnabled) throws JSONException {
-		if (mapConfigEnabled == null && !this.json.isNull("mapConfigEnabled")) {
-			this.json.remove("mapConfigEnabled");
-		} else {
-			this.json.put("mapConfigEnabled", mapConfigEnabled);
-		}
-	}
+    public Boolean isMapConfigEnabled() {
+        return this.isMapConfigEnabled(null);
+    }
+    public Boolean isMapConfigEnabled(Boolean defaultValue) {
+        if (this.json.isNull("mapConfigEnabled")) {
+            return defaultValue;
+        }
+        return this.json.optBoolean("mapConfigEnabled");
+    }
+    public void setMapConfigEnabled(Boolean mapConfigEnabled) throws JSONException {
+        if (mapConfigEnabled == null && !this.json.isNull("mapConfigEnabled")) {
+            this.json.remove("mapConfigEnabled");
+        } else {
+            this.json.put("mapConfigEnabled", mapConfigEnabled);
+        }
+    }
 
-	public Boolean isMapMeasurementEnabled() {
-		return this.isMapMeasurementEnabled(null);
-	}
-	public Boolean isMapMeasurementEnabled(Boolean defaultValue) {
-		if (this.json.isNull("mapMeasurementEnabled")) {
-			return defaultValue;
-		}
-		return this.json.optBoolean("mapMeasurementEnabled");
-	}
-	public void setMapMeasurementEnabled(Boolean mapMeasurementEnabled) throws JSONException {
-		if (mapMeasurementEnabled == null && !this.json.isNull("mapMeasurementEnabled")) {
-			this.json.remove("mapMeasurementEnabled");
-		} else {
-			this.json.put("mapMeasurementEnabled", mapMeasurementEnabled);
-		}
-	}
+    public Boolean isMapMeasurementEnabled() {
+        return this.isMapMeasurementEnabled(null);
+    }
+    public Boolean isMapMeasurementEnabled(Boolean defaultValue) {
+        if (this.json.isNull("mapMeasurementEnabled")) {
+            return defaultValue;
+        }
+        return this.json.optBoolean("mapMeasurementEnabled");
+    }
+    public void setMapMeasurementEnabled(Boolean mapMeasurementEnabled) throws JSONException {
+        if (mapMeasurementEnabled == null && !this.json.isNull("mapMeasurementEnabled")) {
+            this.json.remove("mapMeasurementEnabled");
+        } else {
+            this.json.put("mapMeasurementEnabled", mapMeasurementEnabled);
+        }
+    }
 
-	public Boolean isMapMeasurementLineEnabled() {
-		return this.isMapMeasurementLineEnabled(null);
-	}
-	public Boolean isMapMeasurementLineEnabled(Boolean defaultValue) {
-		if (this.json.isNull("mapMeasurementLineEnabled")) {
-			return defaultValue;
-		}
-		return this.json.optBoolean("mapMeasurementLineEnabled");
-	}
-	public void setMapMeasurementLineEnabled(Boolean mapMeasurementLineEnabled) throws JSONException {
-		if (mapMeasurementLineEnabled == null && !this.json.isNull("mapMeasurementLineEnabled")) {
-			this.json.remove("mapMeasurementLineEnabled");
-		} else {
-			this.json.put("mapMeasurementLineEnabled", mapMeasurementLineEnabled);
-		}
-	}
+    public Boolean isMapMeasurementLineEnabled() {
+        return this.isMapMeasurementLineEnabled(null);
+    }
+    public Boolean isMapMeasurementLineEnabled(Boolean defaultValue) {
+        if (this.json.isNull("mapMeasurementLineEnabled")) {
+            return defaultValue;
+        }
+        return this.json.optBoolean("mapMeasurementLineEnabled");
+    }
+    public void setMapMeasurementLineEnabled(Boolean mapMeasurementLineEnabled) throws JSONException {
+        if (mapMeasurementLineEnabled == null && !this.json.isNull("mapMeasurementLineEnabled")) {
+            this.json.remove("mapMeasurementLineEnabled");
+        } else {
+            this.json.put("mapMeasurementLineEnabled", mapMeasurementLineEnabled);
+        }
+    }
 
-	public Boolean isMapMeasurementAreaEnabled() {
-		return this.isMapMeasurementAreaEnabled(null);
-	}
-	public Boolean isMapMeasurementAreaEnabled(Boolean defaultValue) {
-		if (this.json.isNull("mapMeasurementAreaEnabled")) {
-			return defaultValue;
-		}
-		return this.json.optBoolean("mapMeasurementAreaEnabled");
-	}
-	public void setMapMeasurementAreaEnabled(Boolean mapMeasurementAreaEnabled) throws JSONException {
-		if (mapMeasurementAreaEnabled == null && !this.json.isNull("mapMeasurementAreaEnabled")) {
-			this.json.remove("mapMeasurementAreaEnabled");
-		} else {
-			this.json.put("mapMeasurementAreaEnabled", mapMeasurementAreaEnabled);
-		}
-	}
+    public Boolean isMapMeasurementAreaEnabled() {
+        return this.isMapMeasurementAreaEnabled(null);
+    }
+    public Boolean isMapMeasurementAreaEnabled(Boolean defaultValue) {
+        if (this.json.isNull("mapMeasurementAreaEnabled")) {
+            return defaultValue;
+        }
+        return this.json.optBoolean("mapMeasurementAreaEnabled");
+    }
+    public void setMapMeasurementAreaEnabled(Boolean mapMeasurementAreaEnabled) throws JSONException {
+        if (mapMeasurementAreaEnabled == null && !this.json.isNull("mapMeasurementAreaEnabled")) {
+            this.json.remove("mapMeasurementAreaEnabled");
+        } else {
+            this.json.put("mapMeasurementAreaEnabled", mapMeasurementAreaEnabled);
+        }
+    }
 
-	public String getClientUrl() {
-		return this.json.optString("clientUrl", null);
-	}
-	public void setClientUrl(String clientUrl) throws JSONException {
-		this.json.put("clientUrl", clientUrl);
-	}
+    public String getClientUrl() {
+        return this.json.optString("clientUrl", null);
+    }
+    public void setClientUrl(String clientUrl) throws JSONException {
+        this.json.put("clientUrl", clientUrl);
+    }
 
-	public String getLayerListUrl() {
-		return this.json.optString("layerListUrl", null);
-	}
-	public void setLayerListUrl(String layerListUrl) throws JSONException {
-		this.json.put("layerListUrl", layerListUrl);
-	}
+    public String getLayerListUrl() {
+        return this.json.optString("layerListUrl", null);
+    }
+    public void setLayerListUrl(String layerListUrl) throws JSONException {
+        this.json.put("layerListUrl", layerListUrl);
+    }
 
-	public String getSearchServiceUrl() {
-		return this.json.optString("searchServiceUrl", null);
-	}
-	public void setSearchServiceUrl(String searchServiceUrl) throws JSONException {
-		this.json.put("searchServiceUrl", searchServiceUrl);
-	}
+    public String getSearchServiceUrl() {
+        return this.json.optString("searchServiceUrl", null);
+    }
+    public void setSearchServiceUrl(String searchServiceUrl) throws JSONException {
+        this.json.put("searchServiceUrl", searchServiceUrl);
+    }
 
-	public JSONArray getStartingLocation() {
-		return this.json.optJSONArray("startingLocation");
-	}
-	public void setStartingLocation(JSONArray startingLocation) throws JSONException {
-		this.json.put("startingLocation", startingLocation);
-	}
+    public JSONArray getStartingLocation() {
+        return this.json.optJSONArray("startingLocation");
+    }
+    public void setStartingLocation(JSONArray startingLocation) throws JSONException {
+        this.json.put("startingLocation", startingLocation);
+    }
 
-	public String getLayersPanelHeader() {
-		return this.json.optString("layersPanelHeader", null);
-	}
-	public void setLayersPanelHeader(String layersPanelHeader) throws JSONException {
-		this.json.put("layersPanelHeader", layersPanelHeader);
-	}
+    public String getLayersPanelHeader() {
+        return this.json.optString("layersPanelHeader", null);
+    }
+    public void setLayersPanelHeader(String layersPanelHeader) throws JSONException {
+        this.json.put("layersPanelHeader", layersPanelHeader);
+    }
 
-	public String getLayersPanelFooter() {
-		return this.json.optString("layersPanelFooter", null);
-	}
-	public void setLayersPanelFooter(String layersPanelFooter) throws JSONException {
-		this.json.put("layersPanelFooter", layersPanelFooter);
-	}
+    public String getLayersPanelFooter() {
+        return this.json.optString("layersPanelFooter", null);
+    }
+    public void setLayersPanelFooter(String layersPanelFooter) throws JSONException {
+        this.json.put("layersPanelFooter", layersPanelFooter);
+    }
 
-	public JSONObject getDataSources() {
-		return this.json.optJSONObject("dataSources");
-	}
-	public void setDataSources(JSONObject dataSources) throws JSONException {
-		this.json.put("dataSources", dataSources);
-	}
-	public void addDataSource(String dataSourceId, JSONObject dataSource) throws JSONException {
-		JSONObject dataSources = this.getDataSources();
-		if (dataSources == null) {
-			dataSources = new JSONObject();
-			this.setDataSources(dataSources);
-		}
-		dataSources.put(dataSourceId, dataSource);
-	}
+    public JSONObject getDataSources() {
+        return this.json.optJSONObject("dataSources");
+    }
+    public void setDataSources(JSONObject dataSources) throws JSONException {
+        this.json.put("dataSources", dataSources);
+    }
+    public void addDataSource(String dataSourceId, JSONObject dataSource) throws JSONException {
+        JSONObject dataSources = this.getDataSources();
+        if (dataSources == null) {
+            dataSources = new JSONObject();
+            this.setDataSources(dataSources);
+        }
+        dataSources.put(dataSourceId, dataSource);
+    }
 
 
-	public JSONObject getLayers() {
-		return this.json.optJSONObject("layers");
-	}
-	public void setLayers(JSONObject layers) throws JSONException {
-		this.json.put("layers", layers);
-	}
+    public JSONObject getLayers() {
+        return this.json.optJSONObject("layers");
+    }
+    public void setLayers(JSONObject layers) throws JSONException {
+        this.json.put("layers", layers);
+    }
 
-	public JSONObject getModules() {
-		return this.json.optJSONObject("modules");
-	}
-	public void setModules(JSONObject modules) throws JSONException {
-		this.json.put("modules", modules);
-	}
+    public JSONObject getModules() {
+        return this.json.optJSONObject("modules");
+    }
+    public void setModules(JSONObject modules) throws JSONException {
+        this.json.put("modules", modules);
+    }
 
-	public String getProxyUrl() {
-		return this.json.optString("proxyUrl", null);
-	}
-	public void setProxyUrl(String proxyUrl) throws JSONException {
-		this.json.put("proxyUrl", proxyUrl);
-	}
+    public String getProxyUrl() {
+        return this.json.optString("proxyUrl", null);
+    }
+    public void setProxyUrl(String proxyUrl) throws JSONException {
+        this.json.put("proxyUrl", proxyUrl);
+    }
 }

--- a/src/main/java/au/gov/aims/atlasmapperserver/jsonWrappers/client/DataSourceWrapper.java
+++ b/src/main/java/au/gov/aims/atlasmapperserver/jsonWrappers/client/DataSourceWrapper.java
@@ -260,6 +260,13 @@ public class DataSourceWrapper extends AbstractWrapper {
         this.setValue("status", status);
     }
 
+    public int getLayerCount() {
+        return this.json.optInt("layerCount", 0);
+    }
+    public void setLayerCount(int layerCount) throws JSONException {
+        this.setValue("layerCount", layerCount);
+    }
+
     public boolean isModified() {
         return this.json.optBoolean("modified", false);
     }

--- a/src/main/java/au/gov/aims/atlasmapperserver/thread/AbstractDataSourceConfigThread.java
+++ b/src/main/java/au/gov/aims/atlasmapperserver/thread/AbstractDataSourceConfigThread.java
@@ -78,9 +78,18 @@ public class AbstractDataSourceConfigThread extends AbstractConfigThread {
                 // Set the layers and capabilities overrides into the clone
                 layerCatalog = this.getLayerCatalog(logger, urlcache, dataSourceConfigClone, this.clearCapabilitiesCache, this.clearMetadataCache);
 
-                // Save the data source state into a file
                 if (layerCatalog != null) {
+                    // Save the data source state into the generated datasource file (example: datasources/ea.json)
                     dataSourceConfigClone.save(logger, layerCatalog);
+
+                    // Save the data source state into the server.json config file
+                    int nbLayers = 0;
+                    JSONObject layers = layerCatalog.getLayers();
+                    if (layers != null) {
+                        nbLayers = layers.length();
+                    }
+                    this.dataSourceConfig.setLayerCount(nbLayers);
+                    this.dataSourceConfig.getConfigManager().saveServerConfig();
                 }
             } catch(Exception ex) {
                 logger.log(Level.SEVERE, "An error occurred while generating the layer catalogue: " + Utils.getExceptionMessage(ex), ex);
@@ -89,7 +98,12 @@ public class AbstractDataSourceConfigThread extends AbstractConfigThread {
             if (layerCatalog == null) {
                 // Save the data source error state into a file
                 try {
+                    // Save the data source state into the generated datasource file (example: datasources/ea.json)
                     this.dataSourceConfig.save(logger, null);
+
+                    // Save the data source state into the server.json config file
+                    this.dataSourceConfig.setLayerCount(0);
+                    this.dataSourceConfig.getConfigManager().saveServerConfig();
                 } catch(Exception ex) {
                     logger.log(Level.SEVERE, "An error occurred while saving the data source state: " + Utils.getExceptionMessage(ex), ex);
                 }

--- a/src/main/java/au/gov/aims/atlasmapperserver/thread/ClientConfigThread.java
+++ b/src/main/java/au/gov/aims/atlasmapperserver/thread/ClientConfigThread.java
@@ -178,6 +178,7 @@ public class ClientConfigThread extends AbstractConfigThread {
                     // Flush the proxy cache
                     Proxy.reloadConfig(generatedMainConfig, generatedLayers, this.clientConfig);
 
+                    this.clientConfig.setLayerCount(nbLayers);
                     this.clientConfig.setLastGeneratedDate(new Date());
                     // Write the changes to disk
                     this.clientConfig.getConfigManager().saveServerConfig();

--- a/src/main/webapp/javascript/clientsConfigPage.js
+++ b/src/main/webapp/javascript/clientsConfigPage.js
@@ -897,6 +897,10 @@ Ext.define('Writer.ClientConfigGrid', {
         'Ext.toolbar.TextItem'
     ],
 
+    renderLayerCount: function(layerCount) {
+        return layerCount <= 0 ? '<span class="grid-error">0</span>' : '<span class="grid-success">' + layerCount + '</span>';
+    },
+
     initComponent: function(){
         Ext.apply(this, {
             iconCls: 'icon-grid',
@@ -962,6 +966,12 @@ Ext.define('Writer.ClientConfigGrid', {
                     renderer: function(val) {
                         return val ? '<a href="'+val+'" target="_blank">Preview layers</a>' : '';
                     }
+                }, {
+                    header: 'Layers',
+                    width: 70,
+                    sortable: true,
+                    dataIndex: 'layerCount',
+                    renderer: this.renderLayerCount
                 }, {
                     header: 'Last generated',
                     width: 130,
@@ -1382,6 +1392,7 @@ Ext.define('Writer.ClientConfig', {
         // asUCString: As UpperCase String -> Ignore case sorting
         {name: 'clientId', sortType: 'asUCString'},
         {name: 'clientName', sortType: 'asUCString'},
+        {name: 'layerCount', type: 'int'},
 
         'attributions',
         'welcomeMsg',

--- a/src/main/webapp/javascript/dataSourcesConfigPage.js
+++ b/src/main/webapp/javascript/dataSourcesConfigPage.js
@@ -199,17 +199,15 @@ Ext.define('Writer.LayerServerConfigForm', {
                 qtipHtml: 'A human readable name for this data source. Must be short and descriptive. This field is used as a title for the tab in the <em>Add layer</em> window',
                 name: 'dataSourceName',
                 allowBlank: false
-            }
-        ];
-
-        var advancedItems = [
-            {
+            }, {
                 fieldLabel: 'Tree root',
                 qtipHtml: 'The root element in which the layers of this data source will appear in the client. This can be used to group multiple data sources together.<br/>' +
                     'Default: value of <em>Data source name</em>',
                 name: 'treeRoot'
             }
         ];
+
+        var advancedItems = [];
 
 
         /** Define the KML file URLs grid **/
@@ -959,6 +957,10 @@ Ext.define('Writer.LayerServerConfigGrid', {
         return htmlStatus;
     },
 
+    renderLayerCount: function(layerCount) {
+        return layerCount <= 0 ? '<span class="grid-error">0</span>' : '<span class="grid-success">' + layerCount + '</span>';
+    },
+
     initComponent: function(){
         var that = this;
 
@@ -1007,6 +1009,12 @@ Ext.define('Writer.LayerServerConfigGrid', {
                     flex: 1,
                     sortable: true,
                     dataIndex: 'dataSourceName'
+                }, {
+                    header: 'Layers',
+                    width: 70,
+                    sortable: true,
+                    dataIndex: 'layerCount',
+                    renderer: that.renderLayerCount
                 }, {
                     header: 'Last build',
                     width: 130,
@@ -1609,6 +1617,7 @@ Ext.define('Writer.LayerServerConfig', {
         {name: 'dataSourceName', sortType: 'asUCString'},
         {name: 'layerType', type: 'string'},
         {name: 'lastHarvested', type: 'string'},
+        {name: 'layerCount', type: 'int'},
         'treeRoot',
         'status',
         {name: 'modified', type: 'boolean', defaultValue: false},

--- a/src/main/webapp/resources/style.css
+++ b/src/main/webapp/resources/style.css
@@ -226,6 +226,13 @@ label .grid-warning {
     display: none;
 }
 
+.grid-error {
+    color: #CC0000;
+}
+.grid-success {
+    color: #009900;
+}
+
 .grid-ds-id {
     font-size: 0.9em;
     color: #999999;


### PR DESCRIPTION
Issue #142 v2.0.17
- Added layerCount attribute to AbstractDataSourceConfig and ClientConfig
- Added "Layers" column to the UI (grid) for data sources and clients
- Added layerCount to DataSourceWrapper to have a count in the JSON save state (not required)
- Moved "Tree root" from "Advanced" tab to "General" tab