### PR TITLE
[EAT-133] Add link to metadata record

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>au.gov.aims</groupId>
     <artifactId>atlasmapper</artifactId>
     <packaging>war</packaging>
-    <version>2.1.5</version>
+    <version>2.2.0</version>
     <name>AtlasMapper server and clients</name>
     <description>This application compiled as a single War, that can be deployed in Tomcat, without any other dependency.\n\
 It contains:\n\

--- a/src/main/java/au/gov/aims/atlasmapperserver/xml/TC211/TC211Document.java
+++ b/src/main/java/au/gov/aims/atlasmapperserver/xml/TC211/TC211Document.java
@@ -90,6 +90,36 @@ public class TC211Document {
 		this.polygons.add(polygon);
 	}
 
+	/**
+	 * Call after parsing a document.
+	 * Used to fix up things, like adding a link to the original XML metadata record
+	 * when there is no point of truth URL.
+	 */
+	public void afterParse() {
+		if (!this.hasPointOfTruth()) {
+			Link linkToXMLDocument = new Link();
+			linkToXMLDocument.setName("Original XML metadata record");
+			linkToXMLDocument.setUrl(this.getUri());
+			linkToXMLDocument.setProtocolStr(Protocol.WWW_LINK_1_0_HTTP_METADATA_URL.identifier);
+			this.addLink(linkToXMLDocument);
+		}
+	}
+
+	public boolean hasPointOfTruth() {
+		if (this.links == null || this.links.isEmpty()) {
+			return false;
+		}
+
+		for (Link link : this.links) {
+			Protocol linkProtocol = link == null ? null : link.getProtocol();
+			if (linkProtocol != null && linkProtocol.isPointOfTruth()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	@Override
 	public String toString() {
 		String linksStr = "";
@@ -295,6 +325,10 @@ public class TC211Document {
 
 		public boolean isKML() {
 			return this.identifier != null && this.identifier.startsWith("GLG:KML");
+		}
+
+		public boolean isPointOfTruth() {
+			return this.equals(WWW_LINK_1_0_HTTP_METADATA_URL);
 		}
 	}
 

--- a/src/main/java/au/gov/aims/atlasmapperserver/xml/TC211/TC211Parser.java
+++ b/src/main/java/au/gov/aims/atlasmapperserver/xml/TC211/TC211Parser.java
@@ -288,6 +288,7 @@ public class TC211Parser {
             TC211Handler handler = new TC211Handler(doc);
 
             saxParser.parse(file, handler);
+            doc.afterParse();
         } catch (Exception ex) {
             // Could not parse the document.
             // Check if GeoNetwork returned an access denied (we can't rely on response HTTP code, GeoNetwork does not follow standards)
@@ -326,6 +327,7 @@ public class TC211Parser {
         TC211Handler handler = new TC211Handler(doc);
 
         saxParser.parse(inputStream, handler);
+        doc.afterParse();
 
         return doc;
     }

--- a/src/test/java/au/gov/aims/atlasmapperserver/xml/TC211/TC211ParserTest.java
+++ b/src/test/java/au/gov/aims/atlasmapperserver/xml/TC211/TC211ParserTest.java
@@ -50,7 +50,7 @@ public class TC211ParserTest {
                 doc.getAbstract());
 
         List<TC211Document.Link> links = doc.getLinks();
-        Assert.assertEquals("Number of read links do not match", 2, links.size());
+        Assert.assertEquals("Number of read links do not match", 3, links.size());
 
         for (TC211Document.Link link : links) {
             String linkUrl = link.getUrl();
@@ -74,6 +74,15 @@ public class TC211ParserTest {
 
                 Assert.assertEquals("Link description miss match for link URL: " + linkUrl,
                         "Downloadable Data", link.getDescription());
+
+            } else if (linkUrl.equals("TC211/tc211_iso19139_full.xml")) {
+                Assert.assertEquals("Link protocol miss match for link URL: " + linkUrl,
+                        TC211Document.Protocol.WWW_LINK_1_0_HTTP_METADATA_URL, link.getProtocol());
+
+                Assert.assertEquals("Link name miss match",
+                        "Original XML metadata record", link.getName());
+
+                Assert.assertNull("Link description miss match", link.getDescription());
 
             } else {
                 Assert.fail("Unexpected link URL: " + linkUrl);
@@ -203,22 +212,33 @@ public class TC211ParserTest {
                 doc.getAbstract());
 
         List<TC211Document.Link> links = doc.getLinks();
-        Assert.assertEquals("Number of read links do not match", 1, links.size());
+        Assert.assertEquals("Number of read links do not match", 2, links.size());
 
         for (TC211Document.Link link : links) {
             String linkUrl = link.getUrl();
 
-            Assert.assertEquals("Link URL miss match",
-                    "http://imos2.ersa.edu.au/geo2/imos/wms", linkUrl);
+            if (linkUrl.equals("http://imos2.ersa.edu.au/geo2/imos/wms")) {
+                Assert.assertEquals("Link protocol miss match",
+                        TC211Document.Protocol.OGC_WMS_1_1_1_HTTP_GET_MAP, link.getProtocol());
 
-            Assert.assertEquals("Link protocol miss match",
-                    TC211Document.Protocol.OGC_WMS_1_1_1_HTTP_GET_MAP, link.getProtocol());
+                Assert.assertEquals("Link name miss match",
+                        "imos:ctd_profile_vw", link.getName());
 
-            Assert.assertEquals("Link name miss match",
-                    "imos:ctd_profile_vw", link.getName());
+                Assert.assertEquals("Link description miss match",
+                        "AATAMS Realtime Satellite Animal Tracks", link.getDescription());
 
-            Assert.assertEquals("Link description miss match",
-                    "AATAMS Realtime Satellite Animal Tracks", link.getDescription());
+            } else if (linkUrl.equals("TC211/tc211_iso19139-mcp_AODN-example.xml")) {
+                Assert.assertEquals("Link protocol miss match for link URL: " + linkUrl,
+                        TC211Document.Protocol.WWW_LINK_1_0_HTTP_METADATA_URL, link.getProtocol());
+
+                Assert.assertEquals("Link name miss match",
+                        "Original XML metadata record", link.getName());
+
+                Assert.assertNull("Link description miss match", link.getDescription());
+
+            } else {
+                Assert.fail("Unexpected link URL: " + linkUrl);
+            }
         }
     }
 
@@ -270,7 +290,7 @@ public class TC211ParserTest {
                 doc.getAbstract());
 
         List<TC211Document.Link> links = doc.getLinks();
-        Assert.assertEquals("Number of read links do not match", 1, links.size());
+        Assert.assertEquals("Number of read links do not match", 2, links.size());
 
         for (TC211Document.Link link : links) {
             String linkUrl = link.getUrl();
@@ -284,6 +304,15 @@ public class TC211ParserTest {
 
                 Assert.assertEquals("Link description miss match",
                         "Download data service.", link.getDescription());
+
+            } else if (linkUrl.equals("TC211_201803/tc211_201803_metadata_record.xml")) {
+                Assert.assertEquals("Link protocol miss match for link URL: " + linkUrl,
+                        TC211Document.Protocol.WWW_LINK_1_0_HTTP_METADATA_URL, link.getProtocol());
+
+                Assert.assertEquals("Link name miss match",
+                        "Original XML metadata record", link.getName());
+
+                Assert.assertNull("Link description miss match", link.getDescription());
 
             } else {
                 Assert.fail("Unexpected link URL: " + linkUrl);


### PR DESCRIPTION
v2.2.0
- Added link to the original XML metadata record when there is no Point of Truth URL in the metadata record.
- Modify tests to expect a "Original XML metadata record" link when there is no "Point of Truth" URL.